### PR TITLE
修复：AI接口代码，添加兼容openai-api的各种大模型

### DIFF
--- a/app/controller/app-center/aiChat.ts
+++ b/app/controller/app-center/aiChat.ts
@@ -18,9 +18,9 @@ export default class AiChatController extends Controller {
     const { foundationModel, messages } = ctx.request.body;
     this.ctx.logger.info('ai接口请求参参数 model选型:', foundationModel);
     if (!messages || !Array.isArray(messages)) {
-      ctx.helper.throwError('Not passing the correct message parameter');
+      return this.ctx.helper.getResponseData('Not passing the correct message parameter');
     }
     const model = foundationModel?.model ?? E_FOUNDATION_MODEL.GPT_35_TURBO;
-    ctx.body = await ctx.service.aiChat.getAnswerFromAi(messages, { model });
+    ctx.body = await ctx.service.appCenter.aiChat.getAnswerFromAi(messages, { model });
   }
 }

--- a/app/lib/enum.ts
+++ b/app/lib/enum.ts
@@ -288,5 +288,6 @@ export enum E_Public {
 // AI大模型
 export enum E_FOUNDATION_MODEL {
   GPT_35_TURBO = 'gpt-3.5-turbo', // openai
+  Local_GPT = 'loacl-compatible-gpt-3.5', //本地兼容opanai-api接口的 大语言模型，如chatGLM6b,通义千问 等。
   ERNIE_BOT_TURBO = 'ERNIE-Bot-turbo' // 文心一言
 }

--- a/app/service/app-center/aiChat.ts
+++ b/app/service/app-center/aiChat.ts
@@ -53,11 +53,11 @@ export default class AiChat extends Service {
       // 根据大模型的不同匹配不同的配置
       const aiChatConfig = this.config.aiChat(messages);
       const { httpRequestUrl, httpRequestOption } = aiChatConfig[chatConfig.model];
-      console.log(httpRequestOption)
+      this.ctx.logger.debug(httpRequestOption)
       res = await ctx.curl(httpRequestUrl, httpRequestOption);
 
     } catch (e: any) {
-      console.log(`调用AI大模型接口失败: ${(e as Error).message}`);
+      this.ctx.logger.debug(`调用AI大模型接口失败: ${(e as Error).message}`);
 
       return this.ctx.helper.getResponseData(`调用AI大模型接口失败: ${(e as Error).message}`);
     }

--- a/app/service/app-center/aiChat.ts
+++ b/app/service/app-center/aiChat.ts
@@ -19,7 +19,7 @@ export type AiMessage = {
   content: string; // 聊天内容
 };
 
-export default class AiChatService extends Service {
+export default class AiChat extends Service {
   /**
    * 获取ai的答复
    *
@@ -53,23 +53,30 @@ export default class AiChatService extends Service {
       // 根据大模型的不同匹配不同的配置
       const aiChatConfig = this.config.aiChat(messages);
       const { httpRequestUrl, httpRequestOption } = aiChatConfig[chatConfig.model];
+      console.log(httpRequestOption)
       res = await ctx.curl(httpRequestUrl, httpRequestOption);
+
     } catch (e: any) {
-      ctx.helper.throwError(`调用AI大模型接口失败: ${(e as Error).message}`, e?.status);
+      console.log(`调用AI大模型接口失败: ${(e as Error).message}`);
+
+      return this.ctx.helper.getResponseData(`调用AI大模型接口失败: ${(e as Error).message}`);
     }
 
     if (!res) {
-      ctx.helper.throwError('调用AI大模型接口未返回正确数据');
+
+      return this.ctx.helper.getResponseData(`调用AI大模型接口未返回正确数据.`);
     }
 
     // 适配文心一言的响应数据结构，文心的部分异常情况status也是200，需要转为400，以免前端无所适从
     if (res.data?.error_code) {
-      ctx.helper.throwError(res.data?.error_msg);
+
+      return this.ctx.helper.getResponseData(res.data?.error_msg);
     }
 
     // 适配chatgpt的响应数据结构
     if (res.status !== 200) {
-      ctx.helper.throwError(res.data?.error?.message, res.status);
+
+      return this.ctx.helper.getResponseData(res.data?.error?.message, res.status);
     }
 
     // 适配文心一言的响应数据结构

--- a/config/config.default.ts
+++ b/config/config.default.ts
@@ -250,7 +250,7 @@ export default (appInfo) => {
   config.aiChat = (messages = []) => {
     return {
       [E_FOUNDATION_MODEL.GPT_35_TURBO]: {
-        httpRequestUrl: 'https://api.openai.com/v1/chat/completions',
+        httpRequestUrl: (process.env.OPENAI_API_URL || 'https://api.openai.com')+'/v1/chat/completions',
         httpRequestOption: {
           ...commonRequestOption,
           data: {
@@ -262,6 +262,21 @@ export default (appInfo) => {
           },
         },
         manufacturer: 'openai',
+      },
+      ////本地兼容opanai-api接口的 大语言模型，如chatGLM6b,通义千问 等。你也可以分开成多个
+      [E_FOUNDATION_MODEL.Local_GPT]: {
+        httpRequestUrl: (process.env.Local_GPT_API_URL || 'http://127.0.0.1:8000')+'/v1/chat/completions',
+        httpRequestOption: {
+          ...commonRequestOption,
+          data: {
+            model: E_FOUNDATION_MODEL.Local_GPT,
+            messages,
+          },
+          headers: {
+            Authorization: `Bearer ${process.env.Local_GPT_API_KEY}`,
+          },
+        },
+        manufacturer: '!openai',
       },
       [E_FOUNDATION_MODEL.ERNIE_BOT_TURBO]: {
         httpRequestUrl: `https://aip.baidubce.com/rpc/2.0/ai_custom/v1/wenxinworkshop/chat/eb-instant?access_token=${process.env.WENXIN_ACCESS_TOKEN}`,


### PR DESCRIPTION
添加：本地兼容openai-api的各种大模型(只测了 chatGLM6b,通义千问)
支持：openapi的代理、转发过的自定义接入网址
（注：按照前一次PR要求做了规范修改）